### PR TITLE
DM-36408: Remove unused inheritor and modifier code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Meson/build
 build
+build-release
 builddir
 
 # IDE folders and files

--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,18 @@ using a conda environment:
 
 PKG_CONFIG_PATH=$CONDA_PREFIX/.local/lib64/pkgconfig meson --prefix=$CONDA_PREFIX/.local builddir/
 
-Once the build command is run once to create a build directory, subsequent
-rebuilds can use the provided build.bash script.
+A full example setup script is provided in ``setup_conda.sh``.
+This defaults to  using ``$CONDA_PREFIX``, but can be configured to output
+elsewhere (e.g. ``~/.local``):
 
-Note: the default meson build directory is builddir/, to disambiguate it with
-the command `meson build`. However, many IDEs expect a default build directory
-in build/, as is typical with `cmake`. It may be convient to create a symbolic 
-link between them, e.g. `ln -s builddir build`.
+``CONDA_PREFIX=~ sh setup-conda.sh``
+
+Once the build command is run once to create the build directories, subsequent
+rebuilds can use the provided ``build.sh`` script.
+
+Note: the default meson build directory is builddir/ (build-release is used in
+setup-conda.sh), to disambiguate it with the command `meson build`. However,
+many IDEs expect a build directory in build/, as is typical with `cmake`.
+It may be convient to create a symbolic link between them, e.g.
+`ln -s build-release build`.
 

--- a/build-cc.sh
+++ b/build-cc.sh
@@ -1,1 +1,1 @@
-CXXFLAGS="$CXXFLAGS -O3" meson compile -C builddir && meson test -C builddir && meson install -C builddir
+CXXFLAGS="$CXXFLAGS -O3" meson compile -C build-release && meson test -C build-release && meson install -C build-release

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -112,7 +112,6 @@ private:
     std::unique_ptr<Transformer> _transformer;
 
     std::string _label;
-    SetC _modifiers;
 
     std::shared_ptr<const Limits<T>> _limits_ptr;
     std::shared_ptr<const Transform<T>> _transform_ptr;
@@ -141,11 +140,6 @@ protected:
 
 public:
     static constexpr T _get_default() { return C::_default; }
-    void add_modifier(std::shared_ptr<C> modifier) { 
-        if(modifier == nullptr) throw std::runtime_error("Can't add null modifier to " + this->str());
-        if(_modifiers == nullptr) _modifiers = std::make_unique<SetC>();
-        _modifiers.insert(modifier);
-    }
 
     std::string get_desc() const override { return _get_desc(); }
     T get_default() const override { return _get_default(); }
@@ -157,7 +151,6 @@ public:
     bool get_linear() const override { return _get_linear(); }
     T get_min() const override { return _get_min(); }
     T get_max() const override { return _get_max(); }
-    SetC get_modifiers() const { return _modifiers; }
     std::string get_name() const override { return _get_name(); }
     const Transform<T> & get_transform() const override { return _transformer->transform; }
     T get_transform_derivative() const override {
@@ -169,11 +162,6 @@ public:
     T get_value_transformed() const override { return _value_transformed; }
 
     std::shared_ptr<C> ptr() { return this->shared_from_this(); }
-
-    void remove_modifier(std::shared_ptr<C> modifier) {
-        if(modifier == nullptr) throw std::runtime_error("Can't remove null modifier from " + this->str());
-        _modifiers->erase(modifier); 
-    }
 
     void set_fixed(bool fixed) override { set_free(!fixed); }
     void set_free(bool free) override {
@@ -197,10 +185,6 @@ public:
             _limits_ptr = std::move(limits);
             _limiter = std::make_unique<Limiter>(*_limits_ptr);
         }
-    }
-    void set_modifiers(const SetC modifiers)
-    {   
-        _modifiers = modifiers;
     }
     void set_transform(const std::shared_ptr<const Transform<T>> transform) override {
         if(transform == nullptr) {
@@ -244,13 +228,11 @@ public:
         const std::shared_ptr<const Transform<T>> transform = nullptr,
         std::shared_ptr<const Unit> unit = nullptr,
         bool fixed = false,
-        std::string label = "",
-        const SetC & modifiers = {}
+        std::string label = ""
     ) : ParameterBase<T>() {
         set_limits(limits);
         _value = value;
         set_transform(transform == nullptr ? nullptr : std::move(transform));
-        set_modifiers(modifiers);
         set_unit(unit);
         set_fixed(fixed);
         set_label(label);

--- a/include/parameter.h
+++ b/include/parameter.h
@@ -112,13 +112,11 @@ private:
     std::unique_ptr<Transformer> _transformer;
 
     std::string _label;
-    SetC _inheritors;
     SetC _modifiers;
 
     std::shared_ptr<const Limits<T>> _limits_ptr;
     std::shared_ptr<const Transform<T>> _transform_ptr;
     std::shared_ptr<const Unit> _unit_ptr;
-    std::shared_ptr<const C> _inheritee_ptr = nullptr;
 
     void _set_value(T value)
     {
@@ -141,20 +139,8 @@ protected:
     static constexpr const Limits<T> _limits_maximal = Limits<T>(_get_min(), _get_max(),
         type_name<C>(), ".limits_maximal");
 
-    void set_inheritee(std::shared_ptr<const C> inheritee) {
-        _inheritee_ptr = inheritee == nullptr ? nullptr : std::move(inheritee);
-    }
-
 public:
     static constexpr T _get_default() { return C::_default; }
-    void add_inheritor(std::shared_ptr<C> inheritor) { 
-        if(inheritor == nullptr) throw std::runtime_error("Can't add null inheritor to " + this->str());
-        if(!inheritor->get_free()) throw std::runtime_error("Can't add_inheritor(" + inheritor->str()
-            + ") with fixed inheritor");
-        if(!inheritor->get_inheritors().empty()) throw std::runtime_error("Can't add_inheritor("
-            + inheritor->str() + ") with inheritors of its own; inheritance may not be nested");
-        _inheritors.insert(inheritor);
-    }
     void add_modifier(std::shared_ptr<C> modifier) { 
         if(modifier == nullptr) throw std::runtime_error("Can't add null modifier to " + this->str());
         if(_modifiers == nullptr) _modifiers = std::make_unique<SetC>();
@@ -165,8 +151,6 @@ public:
     T get_default() const override { return _get_default(); }
     bool get_fixed() const override { return !_free; }
     bool get_free() const override { return _free; }
-    std::shared_ptr<const C> get_inheritee() const { return _inheritee_ptr; }
-    SetC get_inheritors() const { return _inheritors; }
     std::string get_label() const override { return _label; }
     const Limits<T> & get_limits_maximal() const override { return _limits_maximal; }
     const Limits<T> & get_limits() const override { return _limiter->limits; }
@@ -186,11 +170,6 @@ public:
 
     std::shared_ptr<C> ptr() { return this->shared_from_this(); }
 
-    void remove_inheritor(std::shared_ptr<C> inheritor) {
-        if(inheritor == nullptr) throw std::runtime_error("Can't remove null inheritor from " + this->str());
-        _inheritors->erase(inheritor); 
-    }
-
     void remove_modifier(std::shared_ptr<C> modifier) {
         if(modifier == nullptr) throw std::runtime_error("Can't remove null modifier from " + this->str());
         _modifiers->erase(modifier); 
@@ -198,15 +177,9 @@ public:
 
     void set_fixed(bool fixed) override { set_free(!fixed); }
     void set_free(bool free) override {
-        if(_inheritee_ptr != nullptr) "Can't set this=" + this->str() + " free while it inherits from "
-            "inheritee = " + _inheritee_ptr->str();
         _free = free;
     }
     void set_label(std::string label) override { _label = std::move(label); }
-    void set_inheritors(const SetC inheritors)
-    {
-        _inheritors = inheritors;
-    }
     void set_limits(std::shared_ptr<const Limits<T>> limits) override {
         // TODO: Fix bad_alloc when calling this without &
 	// Disable copy constructor explicitly maybe?
@@ -247,13 +220,11 @@ public:
         _set_value(value);
         double value_new = this->get_value();
         _value_transformed = _transformer->transform.forward(value_new);
-        for(auto & inheritor : _inheritors) inheritor->set_value(value_new);
     };
     
     void set_value_transformed(T value_transformed) override {
         _set_value(_transformer->transform.reverse(value_transformed));
         _value_transformed = _transformer->transform.forward(this->get_value());
-        for(auto & inheritor : _inheritors) inheritor->set_value_transformed(_value_transformed);
     }
 
     void set_unit(std::shared_ptr<const Unit> unit = nullptr) override {
@@ -274,14 +245,11 @@ public:
         std::shared_ptr<const Unit> unit = nullptr,
         bool fixed = false,
         std::string label = "",
-        const SetC & inheritors = {},
         const SetC & modifiers = {}
     ) : ParameterBase<T>() {
         set_limits(limits);
         _value = value;
         set_transform(transform == nullptr ? nullptr : std::move(transform));
-        // inheritors need to go before value, which is set by set_transform
-        set_inheritors(inheritors);
         set_modifiers(modifiers);
         set_unit(unit);
         set_fixed(fixed);

--- a/setup-conda.sh
+++ b/setup-conda.sh
@@ -1,0 +1,4 @@
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$CONDA_PREFIX/.local/lib64/pkgconfig
+prefix="--prefix=$CONDA_PREFIX/.local"
+meson $prefix --buildtype release build-release
+./build-cc.sh


### PR DESCRIPTION
These features weren't fully implemented and aren't really necessary - inheritance is better achieved by using `std::shared_ptr<Parameter>`, while there are other ways to implement dependent parameters than modifiers.

Also updated the example setup/build scripts.